### PR TITLE
Concurrency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.2.4", features = ["derive"] }
 console = "0.15.5"
-indicatif = "0.17.3"
+indicatif = { version = "0.17.3", features = ["rayon"] }
 inquire = "0.6.1"
 rayon = "1.7.0"
 similar = { version = "2.2.1", features = ["inline"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -401,6 +401,8 @@ fn run_search(args: &Args) -> Result<FileMatches, Box<dyn Error>> {
         .unwrap()
         .progress_chars("#>-");
 
+    let now = std::time::Instant::now();
+
     // Walk through search path
     let mut file_match_vec: Vec<FileMatch> = WalkDir::new(search_root)
         .into_iter()
@@ -415,6 +417,8 @@ fn run_search(args: &Args) -> Result<FileMatches, Box<dyn Error>> {
 
     // Keep the top matches
     file_match_vec.truncate(args.count.into());
+
+    println!("Elapsed: {:.2?}", now.elapsed());
 
     Ok(busca::FileMatches(file_match_vec))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,22 @@
 use busca::{FileMatch, FileMatches};
-// use clap::Arg;
 use clap::Parser;
 use console::{style, Style};
-use indicatif::ProgressIterator;
-// use indicatif::ProgressState;
+use indicatif::ParallelProgressIterator;
 use indicatif::ProgressStyle;
 use inquire::InquireError;
 use inquire::Select;
-// use pariter::IteratorExt::*;
-// use rayon::iter::ParallelBridge;
-// use rayon::prelude::*;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use similar::{ChangeTag, TextDiff};
 use std::env;
 use std::error::Error;
 use std::ffi::OsStr;
 use std::fmt;
-// use std::fmt::Write;
 use std::fs;
 use std::io::ErrorKind;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process;
 use std::process::exit;
-// use std::sync::mpsc::channel;
 use walkdir::WalkDir;
 
 /// Simple utility to find the closest matches to a reference file in a
@@ -198,28 +193,13 @@ mod test_validate_args {
     }
 }
 
-fn compare_file(
-    dir_entry_result: Result<walkdir::DirEntry, walkdir::Error>,
-    args: &Args,
-    ref_lines: &str,
-) -> Option<FileMatch> {
-    if dir_entry_result.is_err() {
-        if args.verbose {
-            println!(
-                "{} | skipped since file cannot be read.",
-                dir_entry_result.unwrap().into_path().display()
-            );
-        }
-        return None;
-    }
-
-    let path_in_dir = dir_entry_result.unwrap().into_path();
+fn compare_file(comp_path: &Path, args: &Args, ref_lines: &str) -> Option<FileMatch> {
     if args.verbose {
-        print!("{}", &path_in_dir.display());
+        print!("{}", &comp_path.display());
     }
 
     // Skip paths that are not files
-    if !path_in_dir.is_file() {
+    if !comp_path.is_file() {
         if args.verbose {
             println!(" | skipped since it is not a file.");
         }
@@ -227,7 +207,7 @@ fn compare_file(
     }
 
     // Skip paths that do not match the extensions
-    let extension = path_in_dir
+    let extension = comp_path
         .extension()
         .unwrap_or(OsStr::new(""))
         .to_os_string()
@@ -241,7 +221,7 @@ fn compare_file(
         return None;
     }
 
-    let comp_reader = fs::read_to_string(&path_in_dir);
+    let comp_reader = fs::read_to_string(comp_path);
     let comp_lines = match comp_reader {
         Ok(lines) => lines,
         Err(error) => match error.kind() {
@@ -267,7 +247,7 @@ fn compare_file(
     }
 
     Some(FileMatch {
-        path: path_in_dir,
+        path: PathBuf::from(comp_path),
         perc_shared,
     })
 }
@@ -298,9 +278,10 @@ mod test_compare_file {
         let dir_entry_result = WalkDir::new("sample_dir_hello_world")
             .into_iter()
             .next()
+            .unwrap()
             .unwrap();
 
-        let file_comparison = compare_file(dir_entry_result, &valid_args, &ref_lines);
+        let file_comparison = compare_file(dir_entry_result.path(), &valid_args, &ref_lines);
 
         assert_eq!(file_comparison, None);
     }
@@ -313,9 +294,13 @@ mod test_compare_file {
 
         let ref_lines = fs::read_to_string(PathBuf::from(file_path_str)).unwrap();
 
-        let dir_entry_result = WalkDir::new(file_path_str).into_iter().next().unwrap();
+        let dir_entry_result = WalkDir::new(file_path_str)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
-        let file_comparison = compare_file(dir_entry_result, &valid_args, &ref_lines);
+        let file_comparison = compare_file(dir_entry_result.path(), &valid_args, &ref_lines);
 
         assert_eq!(
             file_comparison,
@@ -337,9 +322,13 @@ mod test_compare_file {
 
         let comp_path_str = "sample_dir_hello_world/file_1.py";
 
-        let dir_entry_result = WalkDir::new(comp_path_str).into_iter().next().unwrap();
+        let dir_entry_result = WalkDir::new(comp_path_str)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
-        let file_comparison = compare_file(dir_entry_result, &valid_args, &ref_lines);
+        let file_comparison = compare_file(dir_entry_result.path(), &valid_args, &ref_lines);
 
         assert_eq!(
             file_comparison,
@@ -357,9 +346,13 @@ mod test_compare_file {
 
         let comp_path_str = "sample_dir_hello_world/nested_dir/sample_json.json";
 
-        let dir_entry_result = WalkDir::new(comp_path_str).into_iter().next().unwrap();
+        let dir_entry_result = WalkDir::new(comp_path_str)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
-        let file_comparison = compare_file(dir_entry_result, &valid_args, "");
+        let file_comparison = compare_file(dir_entry_result.path(), &valid_args, "");
 
         assert_eq!(
             file_comparison,
@@ -376,9 +369,13 @@ mod test_compare_file {
 
         let comp_path_str = "sample_dir_hello_world/nested_dir/sample_json.json";
 
-        let dir_entry_result = WalkDir::new(comp_path_str).into_iter().next().unwrap();
+        let dir_entry_result = WalkDir::new(comp_path_str)
+            .into_iter()
+            .next()
+            .unwrap()
+            .unwrap();
 
-        let file_comparison = compare_file(dir_entry_result, &valid_args, "");
+        let file_comparison = compare_file(dir_entry_result.path(), &valid_args, "");
 
         assert_eq!(file_comparison, None);
     }
@@ -407,9 +404,12 @@ fn run_search(args: &Args) -> Result<FileMatches, Box<dyn Error>> {
     let mut file_match_vec: Vec<FileMatch> = WalkDir::new(search_root)
         .into_iter()
         .collect::<Vec<_>>()
-        .into_iter()
+        .par_iter()
         .progress_with_style(progress_bar_style)
-        .filter_map(|dir_entry_result| compare_file(dir_entry_result, args, &ref_lines))
+        .filter_map(|dir_entry_result| match dir_entry_result {
+            Ok(dir_entry) => compare_file(dir_entry.path(), args, &ref_lines),
+            Err(_) => None,
+        })
         .collect();
 
     // Sort by percent match

--- a/testing.md
+++ b/testing.md
@@ -15,7 +15,7 @@ cd -
 ## Sample run to time
 
 ```shell
-cargo run -- sample-comprehensive/projects/Billing_system/biling_system.py
+cargo run -- sample-comprehensive/projects/Billing_system/biling_system.py -s sample-comprehensive
 ```
 
 ## Run tests


### PR DESCRIPTION
# Benchmarking

## Definitions

- The Blocking benchmark is from commit SHA `3bd0d0f5b66e5278f83c460a38cc7cb5a39e526d`.
  - [link](https://github.com/noahbaculi/busca/pull/3/commits/3bd0d0f5b66e5278f83c460a38cc7cb5a39e526d)
- The Concurrent benchmark is from commit SHA `1b4c74c2ca6c886119c061362f7fe6bc6965189b`.
  - [link](https://github.com/noahbaculi/busca/pull/3/commits/1b4c74c2ca6c886119c061362f7fe6bc6965189b)

```shell
cargo run --release -- sample-comprehensive/projects/Billing_system/biling_system.py -s sample-comprehensive
```

| Runtime                   | Windows x86 Avg | Mac ARM Avg |
| ------------------------- | --------------: | ----------: |
| Blocking un-optimized (s) |           11.92 |        9.38 |
| Blocking (ms)             |          984.93 |      611.53 |
| Concurrent (ms)           |          322.17 |      242.19 |
| Perc Δ                    |           *33%* |       *40%* |

---

```shell
cargo run --release -- sample_dir_mix/aldras/aldras_core.py -s sample-comprehensive
```

| Runtime                   | Windows x86 Avg | Mac ARM Avg |
| ------------------------- | --------------: | ----------: |
| Blocking un-optimized (s) |            8.65 |        7.39 |
| Blocking (ms)             |          759.06 |      448.56 |
| Concurrent (ms)           |          242.58 |      255.66 |
| Perc Δ                    |           *32%* |       *57%* |

---

```shell
cargo run --release -- sample_dir_mix/aldras/aldras_settings.py -s sample-comprehensive -e json
```

| Runtime                   | Windows x86 Avg | Mac ARM Avg |
| ------------------------- | --------------: | ----------: |
| Blocking un-optimized (s) |            8.65 |        7.39 |
| Blocking (ms)             |           65.64 |       26.88 |
| Concurrent (ms)           |           31.24 |       16.02 |
| Perc Δ                    |           *48%* |       *62%* |

---

```shell
cargo run --release -- sample_dir_mix/aldras/aldras_settings.py -s sample-comprehensive -e py
```

| Runtime                   | Windows x86 Avg | Mac ARM Avg |
| ------------------------- | --------------: | ----------: |
| Blocking un-optimized (s) |            2.23 |        1.88 |
| Blocking (ms)             |          195.39 |      113.40 |
| Concurrent (ms)           |           45.47 |       22.21 |
| Perc Δ                    |           *23%* |       *19%* |
