### PR TITLE
Allow Standard In

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+atty = "0.2.14"
 clap = { version = "4.2.4", features = ["derive"] }
 console = "0.15.5"
 indicatif = { version = "0.17.3", features = ["rayon"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use term_grid::{Alignment, Cell, Direction, Filling, Grid, GridOptions};
 /// assert_eq!(result, 2);
 /// ```
 ///
-pub fn get_num_shared_lines(ref_lines: &str, comp_lines: &str) -> i32 {
+pub fn get_num_shared_lines(ref_lines: &str, comp_lines: &str) -> usize {
     let diff = TextDiff::from_lines(ref_lines, comp_lines);
 
     // let mut num_shared_lines = 0;
@@ -35,7 +35,7 @@ pub fn get_num_shared_lines(ref_lines: &str, comp_lines: &str) -> i32 {
         .filter(|change| change.tag() == ChangeTag::Equal)
         .count();
 
-    num_shared_lines.try_into().unwrap()
+    num_shared_lines
 }
 
 /// Returns the percentage of lines from `ref_lines` that also exist in `comp_lines`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,38 @@ use std::fmt;
 use std::path::PathBuf;
 use term_grid::{Alignment, Cell, Direction, Filling, Grid, GridOptions};
 
+/// Returns the percentage of lines from `ref_lines` that also exist in `comp_lines`.
+///
+/// # Examples
+///
+/// ```
+/// //                ✓   ✓  x   ✓   x      = 3 / 5 = 0.6
+/// let ref_lines = "12\n14\n5\n17\n19\n";
+/// let comp_lines = "11\n12\n13\n14\n15\n16\n\n17\n18\n";
+/// let result = busca::get_perc_shared_lines(ref_lines, comp_lines);
+/// assert_eq!(result, 0.6);
+/// ```
+/// ---
+/// ```
+/// //                ✓   ✓  x   x    = 2 / 4 = 0.5
+/// let ref_lines = "12\n14\n5\n17";
+/// let comp_lines = "11\n12\n13\n14\n15\n16\n\n17\n18\n";
+/// let result = busca::get_perc_shared_lines(ref_lines, comp_lines);
+/// assert_eq!(result, 0.5);
+/// ```
+///
+pub fn get_perc_shared_lines(ref_lines: &str, comp_lines: &str) -> f32 {
+    let num_shared_lines = get_num_shared_lines(ref_lines, comp_lines);
+
+    // If ref file ends with a newline, do not count it as line compared
+    let mut num_ref_lines = ref_lines.split('\n').count();
+    if ref_lines.ends_with('\n') {
+        num_ref_lines -= 1;
+    }
+
+    num_shared_lines as f32 / num_ref_lines as f32
+}
+
 /// Returns the number of lines from `ref_lines` that also exist in `comp_lines`.
 ///
 /// Note: Final new lines are included in the diff comparisons.
@@ -38,37 +70,6 @@ pub fn get_num_shared_lines(ref_lines: &str, comp_lines: &str) -> usize {
     num_shared_lines
 }
 
-/// Returns the percentage of lines from `ref_lines` that also exist in `comp_lines`.
-///
-/// # Examples
-///
-/// ```
-/// //                ✓   ✓  x   ✓   x      = 3 / 5 = 0.6
-/// let ref_lines = "12\n14\n5\n17\n19\n";
-/// let comp_lines = "11\n12\n13\n14\n15\n16\n\n17\n18\n";
-/// let result = busca::get_perc_shared_lines(ref_lines, comp_lines);
-/// assert_eq!(result, 0.6);
-/// ```
-/// ---
-/// ```
-/// //                ✓   ✓  x   x    = 2 / 4 = 0.5
-/// let ref_lines = "12\n14\n5\n17";
-/// let comp_lines = "11\n12\n13\n14\n15\n16\n\n17\n18\n";
-/// let result = busca::get_perc_shared_lines(ref_lines, comp_lines);
-/// assert_eq!(result, 0.5);
-/// ```
-///
-pub fn get_perc_shared_lines(ref_lines: &str, comp_lines: &str) -> f32 {
-    let num_shared_lines = get_num_shared_lines(ref_lines, comp_lines);
-
-    // If ref file ends with a newline, do not count it as line compared
-    let mut num_ref_lines = ref_lines.split('\n').count();
-    if ref_lines.ends_with('\n') {
-        num_ref_lines -= 1;
-    }
-
-    num_shared_lines as f32 / num_ref_lines as f32
-}
 #[derive(Debug, Clone, PartialEq)]
 pub struct FileMatch {
     pub path: PathBuf,
@@ -76,8 +77,6 @@ pub struct FileMatch {
 }
 #[derive(Debug, Clone, PartialEq)]
 pub struct FileMatches(pub Vec<FileMatch>);
-
-// impl FileMatches {}
 
 impl std::ops::Deref for FileMatches {
     type Target = Vec<FileMatch>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,16 @@
 use busca::{FileMatch, FileMatches};
 use clap::Parser;
 use console::{style, Style};
-use indicatif::ParallelProgressIterator;
-use indicatif::ProgressStyle;
-use inquire::InquireError;
-use inquire::Select;
+use indicatif::{ParallelProgressIterator, ProgressStyle};
+use inquire::{InquireError, Select};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use similar::{ChangeTag, TextDiff};
 use std::env;
 use std::error::Error;
-use std::ffi::OsStr;
 use std::fmt;
 use std::fs;
-use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
-use std::process;
-use std::process::exit;
 use walkdir::WalkDir;
 
 /// Simple utility to find the closest matches to a reference file in a
@@ -238,7 +232,7 @@ fn compare_file(comp_path: &Path, args: &Args, ref_lines: &str) -> Option<FileMa
     // Skip paths that do not match the extensions
     let extension = comp_path
         .extension()
-        .unwrap_or(OsStr::new(""))
+        .unwrap_or(std::ffi::OsStr::new(""))
         .to_os_string()
         .into_string()
         .unwrap_or("".to_owned());
@@ -254,7 +248,7 @@ fn compare_file(comp_path: &Path, args: &Args, ref_lines: &str) -> Option<FileMa
     let comp_lines = match comp_reader {
         Ok(lines) => lines,
         Err(error) => match error.kind() {
-            ErrorKind::InvalidData => return None,
+            std::io::ErrorKind::InvalidData => return None,
             other_error => panic!("{:?}", other_error),
         },
     };
@@ -508,7 +502,7 @@ impl fmt::Display for Line {
 
 fn graceful_panic(error_str: String) -> ! {
     eprintln!("{}", error_str);
-    exit(1);
+    std::process::exit(1);
 }
 
 fn main() {
@@ -529,12 +523,12 @@ fn main() {
 
     if grid_options.is_empty() {
         println!("No files found that match the criteria.");
-        process::exit(0);
+        std::process::exit(0);
     }
 
     let ans = match Select::new("Select a file to compare:", grid_options).raw_prompt() {
         Ok(answer) => answer,
-        Err(InquireError::OperationCanceled) => exit(0),
+        Err(InquireError::OperationCanceled) => std::process::exit(0),
         Err(err) => graceful_panic(err.to_string()),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,9 @@ use inquire::{InquireError, Select};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use similar::{ChangeTag, TextDiff};
 use std::env;
-use std::fmt::{self};
-use std::fs::{self};
-use std::path::Path;
-use std::path::PathBuf;
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 /// Output error to the std err and exit with status code 1.


### PR DESCRIPTION
Highly requested feature to allow the reference string to be passed via `stdin`. This allows input to be piped in but has a breaking change:

- The `ref_file_path` is now an optional argument. If it is passed, it overrides any standard input.