### PR TITLE
Include and Exclude flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 atty = "0.2.14"
 clap = { version = "4.2.4", features = ["derive"] }
 console = "0.15.5"
+glob = "0.3.1"
 indicatif = { version = "0.17.3", features = ["rayon"] }
 inquire = "0.6.1"
 rayon = "1.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "busca"
-version = "1.0.1"
+version = "1.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "busca"
-version = "0.1.2"
+version = "1.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,9 +59,13 @@ fn main() {
 /// directory based on the number of lines in the reference file that exist in
 /// each compared file.
 #[derive(Parser, Debug)]
-#[command(author="Noah Baculi", version, about, long_about = None)]
+#[command(author="Noah Baculi", version, about, long_about = None, override_usage="\
+    busca --ref-file-path <REF_FILE_PATH> [OPTIONS]\n       \
+    <SomeCommand> | busca [OPTIONS]"
+)]
 struct InputArgs {
-    /// Local or absolute path to the reference comparison file
+    /// Local or absolute path to the reference comparison file. Overrides any
+    /// piped input
     #[arg(short, long)]
     ref_file_path: Option<PathBuf>,
 
@@ -78,6 +82,14 @@ struct InputArgs {
     /// lines will be skipped.
     #[arg(short, long, default_value_t = 10_000)]
     max_lines: u32,
+
+    /// Substrings in search paths that qualifies that file for comparison
+    #[arg(long)]
+    include: Option<Vec<String>>,
+
+    /// Substrings in search paths that disqualifies that file from comparison
+    #[arg(long)]
+    exclude: Option<Vec<String>>,
 
     /// Number of results to display
     #[arg(short, long, default_value_t = 10)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,10 @@ fn main() {
         std::process::exit(0);
     }
 
-    let ans = match Select::new("Select a file to compare:", grid_options).raw_prompt() {
+    let ans = match Select::new("Select a file to compare:", grid_options)
+        .with_page_size(10)
+        .raw_prompt()
+    {
         Ok(answer) => answer,
         Err(InquireError::OperationCanceled) => std::process::exit(0),
         Err(err) => graceful_panic(&err.to_string()),


### PR DESCRIPTION
Highly requested feature to allow include and exclude globs to fine tune search. This is accompanied by one breaking change:

- The `ext` parameter is now removed since it's functionality is accomplished by the include-glob parameter:

    ```shell
    <SomeCommand> | busca --ext py --ext json
    ```

    is equivalent to 

    ```shell
    <SomeCommand> | busca --include-glob "*.py" --include-glob "*.json"
    ```