### PR TITLE
Fix file reading memoization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "busca"
-version = "2.2.1"
+version = "2.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -21,7 +21,6 @@ console = "0.15.5"
 glob = "0.3.1"
 indicatif = { version = "0.17.3", features = ["rayon"] }
 inquire = "0.6.1"
-memoize = "0.4.0"
 pyo3 = { version = "0.19.2", features = ["extension-module"] }
 rayon = "1.7.0"
 similar = { version = "2.2.1", features = ["inline"] }

--- a/python/test.py
+++ b/python/test.py
@@ -11,20 +11,20 @@ def example_usage():
         reference_string = file.read()
 
     # Perform search with required parameters
-    all_file_matches = busca.search_for_lines(
+    all_file_matches: list[busca.FileMatch] = busca.search_for_lines(
         reference_string=reference_string,
         search_path="./sample_dir_hello_world",
     )
 
     # File matches are returned in descending order of percent match
-    closest_file_match = all_file_matches[0]
+    closest_file_match: busca.FileMatch = all_file_matches[0]
     assert closest_file_match.path == reference_file_path
     assert closest_file_match.percent_match == 1.0
     assert closest_file_match.lines == reference_string
 
     # Perform search for top 5 matches with additional filters
     # to speed up runtime by skipping files that will not match
-    relevant_file_matches = busca.search_for_lines(
+    relevant_file_matches: list[busca.FileMatch] = busca.search_for_lines(
         reference_string=reference_string,
         search_path="./sample_dir_hello_world",
         max_lines=10_000,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,36 @@ fn read_file(comp_path: PathBuf) -> Option<String> {
     Some(comp_lines)
 }
 
+// pub fn flush_read_file_cache() {
+//     memoized_flush_read_file()
+// }
+
+/// Returns the percentage of lines from `ref_lines` that also exist in `comp_lines`.
+///
+///
+/// # Examples
+///
+/// ```
+/// //                ✓   ✓  x   ✓   x      = 3
+/// let ref_lines = "12\n14\n5\n17\n19\n";
+/// let comp_lines = "11\n12\n13\n14\n15\n16\n\n17\n18\n";
+/// let result = busca::get_percent_matching_lines(ref_lines, comp_lines);
+/// assert_eq!(result, 3.0 / 7.0);
+/// ```
+/// ---
+/// ```
+/// //                ✓   ✓  x   x    = 2 / 4 = 0.5
+/// let ref_lines = "12\n14\n5\n17";
+/// let comp_lines = "11\n12\n13\n14\n15\n16\n\n17\n18\n";
+/// let result = busca::get_percent_matching_lines(ref_lines, comp_lines);
+/// assert_eq!(result, 4.0 / 13.0);
+/// ```
+///
+pub fn get_percent_matching_lines(ref_lines: &str, comp_lines: &str) -> f32 {
+    let diff = TextDiff::from_lines(ref_lines, comp_lines);
+    diff.ratio()
+}
+
 #[cfg(test)]
 mod test_compare_file {
     use super::*;
@@ -470,30 +500,4 @@ mod test_compare_file {
 
         assert_eq!(file_comparison, None);
     }
-}
-
-/// Returns the percentage of lines from `ref_lines` that also exist in `comp_lines`.
-///
-///
-/// # Examples
-///
-/// ```
-/// //                ✓   ✓  x   ✓   x      = 3
-/// let ref_lines = "12\n14\n5\n17\n19\n";
-/// let comp_lines = "11\n12\n13\n14\n15\n16\n\n17\n18\n";
-/// let result = busca::get_percent_matching_lines(ref_lines, comp_lines);
-/// assert_eq!(result, 3.0 / 7.0);
-/// ```
-/// ---
-/// ```
-/// //                ✓   ✓  x   x    = 2 / 4 = 0.5
-/// let ref_lines = "12\n14\n5\n17";
-/// let comp_lines = "11\n12\n13\n14\n15\n16\n\n17\n18\n";
-/// let result = busca::get_percent_matching_lines(ref_lines, comp_lines);
-/// assert_eq!(result, 4.0 / 13.0);
-/// ```
-///
-pub fn get_percent_matching_lines(ref_lines: &str, comp_lines: &str) -> f32 {
-    let diff = TextDiff::from_lines(ref_lines, comp_lines);
-    diff.ratio()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use glob::Pattern;
-use memoize::memoize;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
@@ -327,7 +326,6 @@ pub fn compare_file(comp_path: PathBuf, args: &Args, ref_lines: &str) -> Option<
     })
 }
 
-#[memoize]
 fn read_file(comp_path: PathBuf) -> Option<String> {
     let comp_reader = fs::read_to_string(comp_path);
     let comp_lines = match comp_reader {
@@ -339,10 +337,6 @@ fn read_file(comp_path: PathBuf) -> Option<String> {
     };
     Some(comp_lines)
 }
-
-// pub fn flush_read_file_cache() {
-//     memoized_flush_read_file()
-// }
 
 /// Returns the percentage of lines from `ref_lines` that also exist in `comp_lines`.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,59 @@ fn cli_run_search(args: &Args) -> Result<Vec<FileMatch>, String> {
     Ok(file_match_vec)
 }
 
+fn output_detailed_diff(ref_lines: &str, comp_lines: &str) {
+    let diff = TextDiff::from_lines(ref_lines, comp_lines);
+
+    let grouped_operations = diff.grouped_ops(3);
+
+    if grouped_operations.is_empty() {
+        println!("The sequences are identical.");
+        return;
+    }
+
+    for (idx, group) in grouped_operations.iter().enumerate() {
+        if idx > 0 {
+            println!("{:-^1$}", "-", 80);
+        }
+        for op in group {
+            for change in diff.iter_inline_changes(op) {
+                let (sign, s) = match change.tag() {
+                    ChangeTag::Delete => ("-", Style::new().red()),
+                    ChangeTag::Insert => ("+", Style::new().green()),
+                    ChangeTag::Equal => (" ", Style::new().dim()),
+                };
+                print!(
+                    "{} {} {} |",
+                    style(Line(change.old_index())).dim(),
+                    style(Line(change.new_index())).dim(),
+                    s.apply_to(sign).bold(),
+                );
+                for (emphasized, value) in change.iter_strings_lossy() {
+                    if emphasized {
+                        print!("{}", s.apply_to(value).underlined().on_black());
+                    } else {
+                        print!("{}", s.apply_to(value));
+                    }
+                }
+                if change.missing_newline() {
+                    println!();
+                }
+            }
+        }
+    }
+}
+
+struct Line(Option<usize>);
+
+impl fmt::Display for Line {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.0 {
+            None => write!(f, "    "),
+            Some(idx) => write!(f, "{:<4}", idx + 1),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_cli_run_search {
     use super::*;
@@ -386,58 +439,5 @@ mod test_cli_run_search {
             },
         ];
         assert_eq!(cli_run_search(&valid_args).unwrap(), expected);
-    }
-}
-
-fn output_detailed_diff(ref_lines: &str, comp_lines: &str) {
-    let diff = TextDiff::from_lines(ref_lines, comp_lines);
-
-    let grouped_operations = diff.grouped_ops(3);
-
-    if grouped_operations.is_empty() {
-        println!("The sequences are identical.");
-        return;
-    }
-
-    for (idx, group) in grouped_operations.iter().enumerate() {
-        if idx > 0 {
-            println!("{:-^1$}", "-", 80);
-        }
-        for op in group {
-            for change in diff.iter_inline_changes(op) {
-                let (sign, s) = match change.tag() {
-                    ChangeTag::Delete => ("-", Style::new().red()),
-                    ChangeTag::Insert => ("+", Style::new().green()),
-                    ChangeTag::Equal => (" ", Style::new().dim()),
-                };
-                print!(
-                    "{} {} {} |",
-                    style(Line(change.old_index())).dim(),
-                    style(Line(change.new_index())).dim(),
-                    s.apply_to(sign).bold(),
-                );
-                for (emphasized, value) in change.iter_strings_lossy() {
-                    if emphasized {
-                        print!("{}", s.apply_to(value).underlined().on_black());
-                    } else {
-                        print!("{}", s.apply_to(value));
-                    }
-                }
-                if change.missing_newline() {
-                    println!();
-                }
-            }
-        }
-    }
-}
-
-struct Line(Option<usize>);
-
-impl fmt::Display for Line {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
-            None => write!(f, "    "),
-            Some(idx) => write!(f, "{:<4}", idx + 1),
-        }
     }
 }


### PR DESCRIPTION
# Fix File Reading Memoization

## Description

The `read_file` function is memoized to increase the performance of repeated searches. This can cause the cached file contents to be out of date if the file has changed since the last read.

## Tasks

- [x] Compare
   - Boundless memoization
   - Memoization with [`TimeToLive` attribute](https://docs.rs/memoize/0.4.1/memoize/attr.memoize.html)
   - No memoization

    > => Minimal performance impact

- [x] Remove memoization
- [x] Release `v2.3.1`
