### PR TITLE
v3.0.0

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,60 @@
+# Busca
+
+Busca finds files whose contents most closely resemble a reference string. It powers a CLI and a Python library (`busca_py`) over the same Rust core.
+
+## Language
+
+**Reference**:
+The input string (or file contents loaded from `--ref-file-path`) that every candidate is scored against. The reference is fixed for a given run.
+_Avoid_: source, target, query, input
+
+**Search root**:
+The path passed to `--search-path` (or `search_path` in the Python API). Walked recursively to enumerate candidates. May be a directory tree or a single file (a one-candidate degenerate case).
+_Avoid_: search directory, search dir, scan path
+
+**Candidate file**:
+A file reached by walking the search root that survives the include glob, exclude glob, and `max_file_lines` filters. Each candidate produces exactly one `FileComparison`.
+_Avoid_: comp file, match file
+
+**Search**:
+The end-to-end operation: walk the search root, filter to candidates, score each candidate against the reference, and return them ranked by `similarity_ratio`. A search produces zero or more `FileComparison`s.
+_Avoid_: scan, lookup
+
+**Comparison** (`FileComparison`):
+The result of scoring one candidate against the reference. Holds the candidate's path, its `similarity_ratio`, and its contents. A comparison is produced for every candidate, including ones with `similarity_ratio == 0.0`.
+_Avoid_: FileMatch, match, hit, result
+
+**Similarity ratio** (`similarity_ratio`):
+A float in `[0.0, 1.0]` produced by `similar::TextDiff::ratio()`. This is a Ratcliff/Obershelp similarity over the line sequences of the reference and candidate. It is not "the fraction of reference lines that appear in the candidate." See ADR-0001.
+_Avoid_: percent_match, match score, line match percentage
+
+**Include glob** / **Exclude glob** (`include_glob`, `exclude_glob`):
+Glob patterns (per the `glob` crate) applied to candidate paths. A candidate is kept only if it matches at least one include glob (when any are given) and matches no exclude glob.
+_Avoid_: include substring, exclude substring, filter pattern
+
+**`max_file_lines`**:
+A per-candidate size filter. A candidate whose line count exceeds `max_file_lines` is skipped entirely, not truncated. Empty files (zero lines) are also skipped.
+_Avoid_: max_lines (as a "consider only the first N lines" reading)
+
+**`count`**:
+The maximum number of `FileComparison`s returned, taken from the top of the descending `similarity_ratio` ranking. Defaults: `10` (CLI), unlimited (Python).
+_Avoid_: limit, top_k, results
+
+## Flagged ambiguities
+
+- **"match"**: historically used both for "we produced a result for this file" and for "this file actually resembles the reference." Resolved by reserving `FileComparison` for the former and reading `similarity_ratio` for the latter. The Rust type `FileMatch` and the Python `FileMatch` class are scheduled for rename to `FileComparison`.
+- **"search" with a single-file search root**: a search with one candidate is still a search, not a special "compare" mode. The CLI accepts a file at `--search-path` and treats it as a one-candidate search.
+
+## Example dialogue
+
+**Dev**: I ran busca with `--ref-file-path foo.py --search-path ./src` and got a `FileComparison` for `unrelated.json` with `similarity_ratio == 0.0`. Is that a bug?
+
+**Domain**: No. Every candidate that passes the include/exclude globs and `max_file_lines` produces a comparison, even a zero one. If you want to suppress those, narrow the include glob or take a smaller `count`.
+
+**Dev**: Got it. And `similarity_ratio` of `0.43`, that means 43% of the reference lines appear in the candidate?
+
+**Domain**: No, that is the most common misread. It is the `TextDiff::ratio()` from the `similar` crate, a Ratcliff/Obershelp similarity over the line sequences. A line that appears in both contributes, but so does the ordering and the overall structure. See ADR-0001 for the trade-off.
+
+**Dev**: Why is `unrelated.json` even a candidate? I only care about Python files.
+
+**Domain**: You did not pass an include glob. Add `--include-glob '*.py'` and JSON files will be filtered out before they become candidates.

--- a/docs/adr/0001-similarity-ratio-uses-textdiff-ratio.md
+++ b/docs/adr/0001-similarity-ratio-uses-textdiff-ratio.md
@@ -1,0 +1,7 @@
+# Similarity ratio is `TextDiff::ratio()`, not line set membership
+
+Busca's `similarity_ratio` (formerly `percent_match`) is the value returned by `similar::TextDiff::from_lines(reference, candidate).ratio()`, a Ratcliff/Obershelp similarity over the two line sequences. The earlier doc comment on `get_percent_matching_lines` claimed it was "the percentage of lines from the reference that also exist in the candidate," which is not what the code computes and not what we want.
+
+We chose the diff ratio because it captures ordering and structural similarity, not just line presence. Two files that share every line in completely different orders should not score as a perfect match, and two files that differ by one inserted line should not drop sharply. The `similar` crate already implements this well and is the source of the CLI's inline diff view, so reusing it keeps the scoring metric and the diff display consistent.
+
+The trade-off: the metric is harder to explain than "fraction of overlapping lines," and users sometimes read `0.43` as "43% of lines match." That misread is now addressed by the rename to `similarity_ratio` and by an explicit definition in `CONTEXT.md`.


### PR DESCRIPTION
First branch in a v3.0.0 series. Starts with a docs-only commit (`CONTEXT.md` + ADR-0001) establishing canonical language. Subsequent commits on this branch land the breaking renames and the other v3.0.0 scope items below.

## Scope

### Ubiquitous language cleanup (docs landed in first commit, code renames pending) ⚠️ breaking
- Rename `FileMatch` to `FileComparison` (Rust struct, `#[pyclass]`, `busca_py.pyi`)
- Rename `percent_match` to `similarity_ratio`
- Rename Python `search_for_lines(...)` to `search(...)`
- Rename `max_lines` to `max_file_lines` (CLI flag, Python kwarg, Rust field)
- Rename `include_substring` / `exclude_substring` local variables to `include_glob_str` / `exclude_glob_str`
- Fix README "substring 'foo'" wording and the `'**foo**'` example (use `'**/*foo*'`)
- Fix the Rust doc comment on `get_percent_matching_lines` so the prose matches `TextDiff::ratio()`

### Modernization
- Bump Cargo deps (pyo3, similar, clap, walkdir, indicatif, console, inquire) and Python build chain
- Drop the unmaintained `atty` crate and use `std::io::IsTerminal` in `interactive_input_mode()`

### Error handling
- Define a `BuscaError` enum with `thiserror`, replacing `Result<_, String>` across `lib.rs` and `main.rs`
- Map `BuscaError` to `PyValueError` at the Python boundary
- Replace the `todo!()` panic in `main.rs:31` with `graceful_panic`

### New features ⚠️ breaking output shape
- Add `--min-ratio` / `min_ratio` kwarg to drop `FileComparison`s below a similarity threshold
- Add `--output json` mode for machine-consumable CLI results; skips the interactive prompt automatically

### Release
- Bump version to `3.0.0` in `Cargo.toml` and `pyproject.toml`

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo build --release` succeeds
- [ ] `cargo clippy -- -D warnings` passes after the dep bumps
- [ ] `python -m pytest python/test.py` passes against the renamed Python API
- [ ] CLI `busca -h` output matches the new flag names
- [ ] README glob example actually filters files as documented
- [ ] `--output json` round-trips through `jq` cleanly
- [ ] `--min-ratio 0.5` filters out below-threshold comparisons