### PR TITLE
perf: behavior-preserving safe wins (A1-A4, C1, C2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,8 @@ criterion = { version = "0.8", features = ["html_reports"] }
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use rayon::iter::ParallelIterator;
 use rayon::prelude::IntoParallelIterator;
 use similar::TextDiff;
 use std::fs::{self};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use term_grid::{Alignment, Cell, Direction, Filling, Grid, GridOptions};
 use walkdir::WalkDir;
 
@@ -388,7 +388,7 @@ pub(crate) fn compare_file(
         }
     };
 
-    let candidate_content = read_file(candidate_path.clone())?;
+    let candidate_content = read_file(&candidate_path)?;
 
     if let Some(max_file_lines) = args.max_file_lines {
         let num_candidate_lines = candidate_content.lines().count();
@@ -406,8 +406,8 @@ pub(crate) fn compare_file(
     })
 }
 
-fn read_file(candidate_path: PathBuf) -> Option<String> {
-    match fs::read_to_string(&candidate_path) {
+fn read_file(candidate_path: &Path) -> Option<String> {
+    match fs::read_to_string(candidate_path) {
         Ok(content) => Some(content),
         Err(error) if error.kind() == std::io::ErrorKind::InvalidData => None,
         Err(error) => {
@@ -728,14 +728,14 @@ mod test_read_file {
     #[test]
     fn returns_none_on_invalid_data() {
         let path = PathBuf::from("sample_dir_hello_world/nested_dir/sample_json.json");
-        let result = read_file(path);
+        let result = read_file(&path);
         assert!(result.is_some(), "json file should read as UTF-8");
     }
 
     #[test]
     fn returns_none_on_directory_read_without_panicking() {
         let path = PathBuf::from("sample_dir_hello_world");
-        let result = read_file(path);
+        let result = read_file(&path);
         assert_eq!(result, None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,7 +268,7 @@ where
                 Ok(dir_entry) => compare_file(dir_entry.into_path(), args, &args.reference_string),
                 Err(_) => None,
             };
-            let d = done.fetch_add(1, Ordering::SeqCst) + 1;
+            let d = done.fetch_add(1, Ordering::Relaxed) + 1;
             on_progress(d, total);
             out
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use glob::Pattern;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::ParallelIterator;
 use rayon::prelude::IntoParallelIterator;
 use similar::TextDiff;
 use std::fs::{self};
@@ -369,7 +369,7 @@ pub(crate) fn compare_file(
     // Skip paths that do not match any include glob
     if let Some(include_glob) = &args.include_glob {
         let matches_any_include = include_glob
-            .par_iter()
+            .iter()
             .any(|glob| glob.matches_path(candidate_path.as_path()));
 
         if !matches_any_include {
@@ -380,7 +380,7 @@ pub(crate) fn compare_file(
     // Skip paths that match any exclude glob
     if let Some(exclude_glob) = &args.exclude_glob {
         let matches_any_exclude = exclude_glob
-            .par_iter()
+            .iter()
             .any(|glob| glob.matches_path(candidate_path.as_path()));
 
         if matches_any_exclude {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use similar::TextDiff;
 use std::fs::{self};
 use std::path::{Path, PathBuf};
 use term_grid::{Alignment, Cell, Direction, Filling, Grid, GridOptions};
-use walkdir::WalkDir;
+use walkdir::{DirEntry, WalkDir};
 
 use std::fmt;
 
@@ -265,7 +265,7 @@ where
         .into_par_iter()
         .filter_map(|dir_entry_result| {
             let out = match dir_entry_result {
-                Ok(dir_entry) => compare_file(dir_entry.into_path(), args, &args.reference_string),
+                Ok(dir_entry) => compare_file(dir_entry, args, &args.reference_string),
                 Err(_) => None,
             };
             let d = done.fetch_add(1, Ordering::Relaxed) + 1;
@@ -357,14 +357,26 @@ mod test_run_search {
 }
 
 pub(crate) fn compare_file(
-    candidate_path: PathBuf,
+    dir_entry: DirEntry,
     args: &Args,
     reference_string: &str,
 ) -> Option<FileComparison> {
-    // Skip paths that are not files
-    if !candidate_path.is_file() {
+    // file_type() comes from the directory read at no extra syscall, where
+    // is_file() would re-stat every candidate. For a symlink, fall back to
+    // is_file() so the link is followed exactly as before.
+    let file_type = dir_entry.file_type();
+    let is_file = if file_type.is_file() {
+        true
+    } else if file_type.is_symlink() {
+        dir_entry.path().is_file()
+    } else {
+        false
+    };
+    if !is_file {
         return None;
     }
+
+    let candidate_path = dir_entry.into_path();
 
     // Skip paths that do not match any include glob
     if let Some(include_glob) = &args.include_glob {
@@ -473,7 +485,7 @@ mod test_compare_file {
             .unwrap();
 
         let file_comparison =
-            compare_file(dir_entry_result.into_path(), &valid_args, &reference_string);
+            compare_file(dir_entry_result, &valid_args, &reference_string);
 
         assert_eq!(file_comparison, None);
     }
@@ -493,7 +505,7 @@ mod test_compare_file {
             .unwrap();
 
         let file_comparison =
-            compare_file(dir_entry_result.into_path(), &valid_args, &reference_string);
+            compare_file(dir_entry_result, &valid_args, &reference_string);
 
         assert_eq!(
             file_comparison,
@@ -522,7 +534,7 @@ mod test_compare_file {
             .unwrap();
 
         let file_comparison =
-            compare_file(dir_entry_result.into_path(), &valid_args, &reference_string);
+            compare_file(dir_entry_result, &valid_args, &reference_string);
 
         assert_eq!(
             file_comparison,
@@ -547,7 +559,7 @@ mod test_compare_file {
             .unwrap()
             .unwrap();
 
-        let file_comparison = compare_file(dir_entry_result.into_path(), &valid_args, "");
+        let file_comparison = compare_file(dir_entry_result, &valid_args, "");
 
         assert_eq!(
             file_comparison,
@@ -572,7 +584,7 @@ mod test_compare_file {
             .unwrap()
             .unwrap();
 
-        let file_comparison = compare_file(dir_entry_result.into_path(), &valid_args, "");
+        let file_comparison = compare_file(dir_entry_result, &valid_args, "");
 
         assert_eq!(file_comparison, None);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::perf, clippy::complexity)]
 use glob::Pattern;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;


### PR DESCRIPTION
Behavior-preserving performance and build changes from the performance audit. The `test_run_search` and `test_compare_file` suites assert exact output and ordering and pass unchanged, which is the proof that behavior is preserved.

## Changes

- **A1**: Drop the nested rayon in glob matching. The include and exclude checks in `compare_file` used `par_iter().any(...)` over a glob list that is usually one or two patterns, while already running inside the outer `into_par_iter()` over directory entries. Switched both to `iter().any(...)`, removing the work-stealing overhead on an already saturated pool.
- **A2**: Relax the progress counter from `Ordering::SeqCst` to `Ordering::Relaxed`. Its only consumer is the progress bar, so the global ordering fence on every file is unnecessary. The total count stays exact.
- **A3**: `read_file` borrows `&Path` instead of owning a `PathBuf`, removing the per-candidate clone at the call site. The owned path still moves into `FileComparison` as before.
- **A4**: Use the `walkdir::DirEntry` file type instead of re-`stat`ing each candidate with `Path::is_file()`. `file_type()` comes from the directory read at no extra syscall. Symlink-preserving: a symlink entry falls back to `path().is_file()`, so every input class (regular file, directory, symlink-to-file, broken symlink) resolves exactly as before.
- **C1**: Add a `[profile.release]` section with `codegen-units = 1` and `strip = true`.
    - `lto = "thin"`, not `"fat"`. This crate builds both a pyo3 `cdylib` (`extension-module`, which leaves libpython unlinked) and a standalone `bin`. Fat LTO fuses the unused `#[pymodule]` glue into the binary and defeats dead-code stripping, so the link fails on undefined Python symbols. Thin LTO keeps the codegen-unit boundaries, the glue is stripped, and the binary links while still getting cross-crate optimization. Making fat LTO work would mean feature-gating the extension-module code off the `bin` target, which is out of scope here.
    - No `panic = "abort"`: pyo3 relies on unwinding across the FFI boundary.
- **C2**: Gate `clippy::perf` and `clippy::complexity` at the crate level. Clean on the current code.

## Benchmarking

The criterion `run_search` bench couldn't resolve A1-A4 from measurement noise on my machine: all count variants reported no change with confidence intervals straddling zero, and `get_similarity_ratio`, a path this PR never touches, swung +4% on the same run. So I'm not attaching a misleading numbers table. These are reasoned safe wins backed by the unchanged test suite, not a measured speedup. C1's LTO does not show up in `cargo bench` at all, since `[profile.bench]` uses the default opt-level 3 and does not inherit `[profile.release]`.
